### PR TITLE
Allow to use dry_run on open PR event to compute next tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,11 @@ title attached to the PR or based on the `milestone_pattern` input (default to `
 
 ## Outputs
 
-| Variable       | Type   | Description          |
-| -------------- | ------ | -------------------- |
-| `new_tag`      | String | New tag created.     |
-| `previous_tag` | String | Previous tag if any. |
+| Variable       | Type    | Description                                         |
+| -------------- | ------- | --------------------------------------------------- |
+| `new_tag`      | String  | New tag created.                                    |
+| `previous_tag` | String  | Previous tag if any.                                |
+| `tag_created`  | Boolean | `true` if a tag has been created, `false` otherwise |
 
 ## Example usage
 
@@ -66,7 +67,6 @@ on:
       - closed
     branches:
       - master
-
 
 jobs:
   release:

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,8 @@ outputs:
     description: 'New tag'
   previous_tag:
     description: 'Previous tag'
+  tag_created:
+    description: '"true" if a tag has been created, "false" otherwise'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/src/action.ts
+++ b/src/action.ts
@@ -43,22 +43,23 @@ export default async function action(): Promise<void> {
   core.info(`PR merged: ${pullRequest.merged}`)
   core.info(`PR state: ${pullRequest.state}`)
 
-  if (!pullRequest.merged) {
-    core.info('Ignore non merged pull request')
-    return
-  }
-
   const newTag = await computeTags(pullRequest)
+  core.setOutput('new_tag', newTag)
+  core.setOutput('tag_created', false)
 
-  const {GITHUB_SHA} = process.env
-  if (!GITHUB_SHA) {
-    throw Error('GITHUB_SHA environment variable not defined')
+  if (!pullRequest.merged) {
+    core.warning('Ignore non merged pull request')
+    return
   }
 
   if (core.getBooleanInput('dry_run')) {
     core.warning('Dry run set, tag is not created')
   } else {
+    const {GITHUB_SHA} = process.env
+    if (!GITHUB_SHA) {
+      throw Error('GITHUB_SHA environment variable not defined')
+    }
     createTag(newTag, GITHUB_SHA)
-    core.setOutput('new_tag', newTag)
+    core.setOutput('tag_created', true)
   }
 }


### PR DESCRIPTION
The dry_run option did not set the new_tag output parameter and we could
not use the action to compute future tag when opening a PR due to the
pullRequest.merged check.

So now we can use the dry_run=true on the PR open to compute the tag
that would be used in the merge event.